### PR TITLE
Fix folded image load error cursor mis position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 tmp/
+.DS_Store

--- a/hypermd/addon/fold.js
+++ b/hypermd/addon/fold.js
@@ -239,6 +239,11 @@
       img.classList.remove("hmd-image-loading")
       marker.changed()
     }, false)
+    img.addEventListener("error", function() {
+      img.classList.remove("hmd-image-loading")
+      img.classList.add("hmd-image-error")
+      marker.changed()
+    })
     img.setAttribute("src", url)
     img.addEventListener("click", function () {
       breakMark(cm, marker, 2)


### PR DESCRIPTION
If the image url is incorrect, the image will always have "hmd-image-loading" class, which may cause the cursor mispositioned in some theme (with min-height). Added this handling for load error and add a new class.

Also add unnecessary file to gitignore.