### PR TITLE
package: set codemirror as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
     "turndown-plugin-gfm": "^1.0.1",
     "typescript": "^2.8.3"
   },
+  "peerDependencies": {
+    "codemirror": "^5.37.0"
+  },
   "dependencies": {
-    "codemirror": "^5.37.0",
     "marked": "^0.3.19"
   }
 }


### PR DESCRIPTION
This is required, because hypermd is a mode of codemirror, and it needs to be instanciated on the codemirror instance of the client, so it should not provide its own version of codemirror.