### PR TITLE
[keymap] use cmd key for keymaps when on mac

### DIFF
--- a/src/keymap/hypermd.ts
+++ b/src/keymap/hypermd.ts
@@ -624,23 +624,24 @@ Object.assign(CodeMirror.commands, {
 })
 
 const defaultKeyMap = CodeMirror.keyMap["default"]
+const modPrefix = defaultKeyMap === CodeMirror.keyMap["macDefault"] ? "Cmd" : "Ctrl"
 export var keyMap: CodeMirror.KeyMap = {
   "Shift-Tab": "hmdShiftTab",
   "Tab": "hmdTab",
   "Enter": "hmdNewlineAndContinue",
   "Shift-Enter": "hmdNewline",
 
-  "Ctrl-B": createStyleToggler(
+  [`${modPrefix}-B`]: createStyleToggler(
     state => state.strong,
     token => / formatting-strong /.test(token.type),
     state => repeatStr(state && state.strong || "*", 2)     // ** or __
   ),
-  "Ctrl-I": createStyleToggler(
+  [`${modPrefix}-I`]: createStyleToggler(
     state => state.em,
     token => / formatting-em /.test(token.type),
     state => (state && state.em || "*")
   ),
-  "Ctrl-D": createStyleToggler(
+  [`${modPrefix}-D`]: createStyleToggler(
     state => state.strikethrough,
     token => / formatting-strikethrough /.test(token.type),
     state => "~~"


### PR DESCRIPTION
I used [the MirrorMark project](https://github.com/gilbert/MirrorMark/blob/master/src/js/mirrormark.js#L86) as an example for this.